### PR TITLE
Migrate to use v0.14 Filter Plugin API

### DIFF
--- a/lib/fluent/plugin/filter_gcloud_metadata.rb
+++ b/lib/fluent/plugin/filter_gcloud_metadata.rb
@@ -1,10 +1,10 @@
-require 'fluent/filter'
+require 'fluent/plugin/filter'
 require 'net/http'
 require 'uri'
 
-module Fluent
+module Fluent::Plugin
 
-  class GcloudMetadataFilter <  Fluent::Filter
+  class GcloudMetadataFilter <  Filter
     class ConnectionFailure < StandardError; end
     Fluent::Plugin.register_filter('gcloud_metadata', self)
 


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,